### PR TITLE
Add dark mode scrollbar, input & select elements

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -3,6 +3,10 @@ body {
   @apply antialiased text-gray-700 dark:text-white dark:bg-gray-900;
 }
 
+html.dark {
+  color-scheme: dark;
+}
+
 .dots-pattern-background {
   background-image: url("data:image/svg+xml,%3Csvg width='8' height='8' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23edf2f7' fill-opacity='1' fill-rule='evenodd'%3E%3Ccircle cx='3' cy='3' r='3'/%3E%3Ccircle cx='13' cy='13' r='3'/%3E%3C/g%3E%3C/svg%3E");
 }


### PR DESCRIPTION
Use `color-scheme: dark` when `html.dark` is applied, this ensures that scrollbars, inputs, and select elements all support native dark mode.